### PR TITLE
Documentation links and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently known supported units are:
 - TS-1677x
 - TS-253B
 - TS-453A
-- TS-464 (Instructions in Repo as TS464.md)
+- TS-464 (Instructions in Repo here: https://github.com/ich777/unraid-qnapec/blob/master/TS464.md)
+
+Github Repo: https://github.com/ich777/unraid-qnapec/tree/master
 
 Support Thread: https://forums.unraid.net/topic/92865-support-ich777-nvidiadvbzfsiscsimft-kernel-helperbuilder-docker/

--- a/TS464.md
+++ b/TS464.md
@@ -35,7 +35,7 @@ SSH into your UnRAID server and execute the following command:
 ```bash
 mkdir -p /boot/config/modprobe.d
 echo "options qnap-ec check-for-chip=no" > /boot/config/modprobe.d/qnap-ec.config
-modrpobe qnap-ec check-for-chip=no
+modprobe qnap-ec check-for-chip=no
 ```
 This will create a file on the boot drive so that you don't have to load the driver manually on next reboot with the option `check-for-chip=no` and finally load the QNAP-EC kernel module and skip the chip presence check for the existing session.
 


### PR DESCRIPTION
Hello ich777,

Thank you so much for this awesome plugin and the recent patch. I was contemplating going back to the QNAP OS after the fans were not detected in Unraid, but now it works great!

That being said, I had to search for the repo to find the TS464.md documentation from the description. To make it easier I added a link to the markdown in the documentation and also a link to your repo at the bottom.

I see that there seems to be somekind of Keyword "Support Thread" being used by unraid to provide the "Support Thread" button in the app selection. Maybe there is one for the Repo as well?

There was also a typo in "modprobe" which I noticed when pasting the commands.

Cheers, have a good day.